### PR TITLE
fix(deploy): Pass the dotfiles option as a flag

### DIFF
--- a/sontek-frontend/package.json
+++ b/sontek-frontend/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "dev": "next dev",
-        "deploy": "gh-pages -d out -t true",
+        "deploy": "gh-pages -d out -t",
         "build": "next build --webpack",
         "export": "next build --webpack",
         "format": "prettier --write .",

--- a/sontek-frontend/tests/deploy-command.test.mjs
+++ b/sontek-frontend/tests/deploy-command.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("passes the gh-pages dotfiles option as a boolean flag", async () => {
+    const packageJson = JSON.parse(
+        await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    );
+
+    assert.equal(packageJson.scripts.deploy, "gh-pages -d out -t");
+});


### PR DESCRIPTION
Fix the production publish step for the current `gh-pages` command-line interface.

Version 6 treats the dotfiles option as a boolean flag. The existing command passed an extra value, so deployment stopped after a successful static build. A regression test now protects the corrected command.

This follows the JSON Resume deployment work in #56.
